### PR TITLE
Fix: command status error float/int

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ notifications. To use this daemon, launch it manually when needed or add this
 to your i3 configuration to launch it on startup:
 
 ```
-exec python ~/repos/i3-gnome-/pomodoro-client.py daemon &
+exec python ~/repos/i3-gnome-/pomodoro-client.py daemon &
 ```
 
 If you want to disable any workspaces during your pomodoro, you can do so by
 specifying there workspace number. For example, I generally use workspace 10
 for IM, Social Media and Workspace 9 for email. Therefore I want them disabled
-while I'm on a pomodoro. So, I execute my daemon like this:
+while I'm on a pomodoro. So, I execute my daemon like this:
 
 ```
-exec python ~/repos/i3-gnome-/pomodoro-client.py daemon 9 10 &
+exec python ~/repos/i3-gnome-/pomodoro-client.py daemon 9 10 &
 ```
 
 This works even if you label your workspaces. For example, I use the name "9: mail"
@@ -109,7 +109,7 @@ for my email workspace but I still reference it with "9".
 I also like to have a nagbar warning shown when I still try to access a distracting workspace:
 
 ```
-exec python ~/repos/i3-gnome-/pomodoro-client.py daemon 9 10 --nagbar &
+exec python ~/repos/i3-gnome-/pomodoro-client.py daemon 9 10 --nagbar &
 ```
 
 

--- a/pomodoro-client.py
+++ b/pomodoro-client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import math
 from threading import Thread
 from subprocess import Popen

--- a/pomodoro-client.py
+++ b/pomodoro-client.py
@@ -21,8 +21,8 @@ def get_pomodoro_proxy():
 
 def format_time(seconds):
     return "{minutes:02d}:{seconds:02d}".format(
-        minutes=math.floor(seconds / 60),
-        seconds=round(seconds % 60)
+        minutes=int(math.floor(seconds / 60)),
+        seconds=int(round(seconds % 60))
     )
 
 


### PR DESCRIPTION
This patch fix an error when calling `python pomodoro-client.py status`

The error was : `ValueError: Unknown format code 'd' for object of type 'float'`