### PR TITLE
Fix issue where i3-gnome-pomodoro outputs mm:60

### DIFF
--- a/pomodoro-client.py
+++ b/pomodoro-client.py
@@ -21,7 +21,7 @@ def get_pomodoro_proxy():
     return bus.get("org.gnome.Pomodoro", "/org/gnome/Pomodoro")
 
 
-def format_time(seconds, show_seconds): 
+def format_time(seconds, show_seconds):
     time = "{minutes:02d}".format(minutes=int(math.floor(round(seconds)/60))) + (
         ":{seconds:02d}".format(seconds=int(round(seconds) % 60)) if show_seconds
         else "m"

--- a/pomodoro-client.py
+++ b/pomodoro-client.py
@@ -21,9 +21,9 @@ def get_pomodoro_proxy():
     return bus.get("org.gnome.Pomodoro", "/org/gnome/Pomodoro")
 
 
-def format_time(seconds, show_seconds):
-    time = "{minutes:02d}".format(minutes=int(math.floor(seconds / 60))) + (
-        ":{seconds:02d}".format(seconds=int(round(seconds % 60))) if show_seconds 
+def format_time(seconds, show_seconds): 
+    time = "{minutes:02d}".format(minutes=int(math.floor(round(seconds)/60))) + (
+        ":{seconds:02d}".format(seconds=int(round(seconds) % 60)) if show_seconds
         else "m"
     )
 


### PR DESCRIPTION
This should resolve issue #32, where the issue was that it outputs `mm:60` when `59 < (seconds % 60)`